### PR TITLE
Import upstream PR #515: Added tutorial - Recreacting the linux 'which' command in go - Beginner friendly tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 - [Building a TCP Chat in Go(video)](https://www.youtube.com/watch?v=Sphme0BqJiY)
 - [Building a BitTorrent client from the ground up in Go](https://blog.jse.li/posts/torrent/)
 - [REST API masterclass with Go, PostgreSQL and Docker(video playlist)`in progress`](https://www.youtube.com/watch?v=rx6CPDK_5mU&list=PLy_6D98if3ULEtXtNSY_2qN21VCKgoQAE)
+- [Recreating the Linux 'Which' Command in Go](https://aubiss.com/posts/recreating-which-command-in-go/)
 
 ## PHP:
 


### PR DESCRIPTION
Imported from practical-tutorials/project-based-learning#515