### PR TITLE
Import upstream PR #538: Fix broken link in README.md for "Build an App in Pure JS" tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 ## JavaScript:
 
 - [Build 30 things in 30 days with 30 tutorials](https://javascript30.com)
-- [Build an App in Pure JS](https://medium.com/codingthesmartway-com-blog/pure-javascript-building-a-real-world-application-from-scratch-5213591cfcd6)
+- [Build an App in Pure JS](https://www.codingthesmartway.com/pure-javascript-building-a-real-world-application-from-scratch/)
 - [Build a Jupyter Notebook Extension](https://link.medium.com/wWUO7TN8SS)
 - [Build a TicTacToe Game with JavaScript](https://medium.com/javascript-in-plain-english/build-tic-tac-toe-game-using-javascript-3afba3c8fdcc)
 - [Build a Simple Weather App With Vanilla JavaScript](https://webdesign.tutsplus.com/tutorials/build-a-simple-weather-app-with-vanilla-javascript--cms-33893)


### PR DESCRIPTION
Imported from practical-tutorials/project-based-learning#538

Original author: @unknown
Original title: Fix broken link in README.md for "Build an App in Pure JS" tutorial