### PR TITLE
Update SwiftUI tutorial link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,7 +826,7 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 ## Swift:
 
 - [Hacking with Swift - Learn Swift by doing 39 projects](https://www.hackingwithswift.com/read)
-- [Apple SwiftUI Tutorials (Build Apps by Creating Real Projects)](https://developer.apple.com/tutorials/swiftui)
+- [Apple SwiftUI Tutorials (Build Apps by Creating Real Projects)](https://developer.apple.com/tutorials/develop-in-swift/)
 - [Retro first-person shooter from scratch](https://github.com/nicklockwood/RetroRampage)
 
 ## Streamlit:


### PR DESCRIPTION
Previous link warns that tutorial is deprecated, and should move to the updated link.

Exact Warning:
"This tutorial no longer demonstrates current SwiftUI or Xcode practices. For tutorials supporting the latest OS and tools releases, see Develop in Swift."